### PR TITLE
トップページに今日の掃除当番の情報を表示する

### DIFF
--- a/src/main/java/jp/co/esm/miffy/Controller/Asf4MemberController.java
+++ b/src/main/java/jp/co/esm/miffy/Controller/Asf4MemberController.java
@@ -19,8 +19,8 @@ public class Asf4MemberController {
     public String index(Model model) {
         List<Asf4Member> asf4MemberList = hookService.selectAll();
         model.addAttribute("asf4MemberList", asf4MemberList);
-        //デバッグ用
-        //hookComponent.postToHook();
+        // デバッグ用
+        // hookComponent.postToHook();
         return "asf4members";
     }
 }

--- a/src/main/java/jp/co/esm/miffy/Controller/MemberInfoController.java
+++ b/src/main/java/jp/co/esm/miffy/Controller/MemberInfoController.java
@@ -35,7 +35,6 @@ public class MemberInfoController {
     @ModelAttribute("/asf4Member")
     public Asf4Member createAsf4Member() {
         Asf4Member asf4Member = new Asf4Member();
-        System.out.println("メンバー情報" + asf4Member);
         return asf4Member;
     }
 

--- a/src/main/java/jp/co/esm/miffy/Controller/MemberInfoController.java
+++ b/src/main/java/jp/co/esm/miffy/Controller/MemberInfoController.java
@@ -35,6 +35,7 @@ public class MemberInfoController {
     @ModelAttribute("/asf4Member")
     public Asf4Member createAsf4Member() {
         Asf4Member asf4Member = new Asf4Member();
+        System.out.println("メンバー情報" + asf4Member);
         return asf4Member;
     }
 

--- a/src/main/java/jp/co/esm/miffy/entity/Asf4Member.java
+++ b/src/main/java/jp/co/esm/miffy/entity/Asf4Member.java
@@ -36,5 +36,5 @@ public class Asf4Member {
   private String note;
 
   @Column(name = "is_cleaner")
-  private boolean isCleaner;
+  private boolean cleaner;
 }

--- a/src/main/java/jp/co/esm/miffy/repository/Asf4MemberRepository.java
+++ b/src/main/java/jp/co/esm/miffy/repository/Asf4MemberRepository.java
@@ -37,9 +37,9 @@ public interface Asf4MemberRepository extends JpaRepository<Asf4Member, Integer>
     Optional<Asf4Member> findTopBySkipFalseOrderByIdAsc();
 
     /**
-     * IsCleaner==trueのメンバー情報を取得する
+     * Cleaner==trueのメンバー情報を取得する
      *
      * @return 条件に一致するメンバー情報をOptional型で返す
      */
-    Optional<Asf4Member> findByIsCleanerTrue();
+    Optional<Asf4Member> findByCleanerTrue();
 }

--- a/src/main/java/jp/co/esm/miffy/service/HookService.java
+++ b/src/main/java/jp/co/esm/miffy/service/HookService.java
@@ -31,7 +31,7 @@ public class HookService {
      * @return 前回の掃除当番をAsf4Memberクラスで返す。
      */
     private Asf4Member getLastCleaner() {
-        Optional<Asf4Member> lastCleanerOptional = asf4MemberRepository.findByIsCleanerTrue();
+        Optional<Asf4Member> lastCleanerOptional = asf4MemberRepository.findByCleanerTrue();
         return lastCleanerOptional.orElseThrow(() -> new NoSuchElementException("IsCleaner == true に一致する情報がありません。"));
     }
 

--- a/src/main/resources/templates/asf4members.html
+++ b/src/main/resources/templates/asf4members.html
@@ -37,7 +37,9 @@
                     <th>今日の掃除当番</th>
                 </tr>
             </thead>
-            <tr th:each="list : ${asf4MemberList}" th:object="${list}">
+            <tr th:each="list : ${asf4MemberList}"
+                th:object="${list}"
+                th:style="*{cleaner} == true ? 'background: pink' : 'background: white'">
                 <td th:text="*{id}"></td>
                 <td th:text="*{name}"></td>
                 <td th:text="'@' + *{idobataId}"></td>

--- a/src/main/resources/templates/asf4members.html
+++ b/src/main/resources/templates/asf4members.html
@@ -34,6 +34,7 @@
                     <th>idobataID</th>
                     <th>掃除当番skip</th>
                     <th>備考</th>
+                    <th>今日の掃除当番</th>
                 </tr>
             </thead>
             <tr th:each="list : ${asf4MemberList}" th:object="${list}">
@@ -42,6 +43,7 @@
                 <td th:text="'@' + *{idobataId}"></td>
                 <td th:text="*{skip}"></td>
                 <td th:text="*{note}"></td>
+                <td th:text="*{cleaner}"></td>
         </table>
     </div>
 </body>


### PR DESCRIPTION
close #32 

### やったこと
- 今日の掃除当番の情報(`is_cleaner`が`true`のデータ)を取得する
- 表示されているテーブルについて、今日の掃除当番者の行だけ背景をピンクにする
![image](https://user-images.githubusercontent.com/63690842/100399880-d368fc80-3097-11eb-84fc-2373dcd86464.png)

### ~~困っていること~~ 困っていたが解決したこと
トップページ`/asf4members`を表示するとエラーが出る
```
Caused by: org.attoparser.ParseException: Exception evaluating SpringEL expression: "isCleaner" (template: "asf4members" - line 37, col 21)
```
```
Caused by: org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating SpringEL expression: "isCleaner" (template: "asf4members" - line 37, col 21)
```
```
Caused by: org.springframework.expression.spel.SpelEvaluationException: EL1008E: Property or field 'isCleaner' cannot be found on object of type 'jp.co.esm.miffy.entity.Asf4Member' - maybe not public or not valid?
```
entity で `isCleaner` を public にすれば期待通り表示されたが private にしたい